### PR TITLE
Choose first OSGi jar found

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -6,7 +6,7 @@ function setup_home () {
     echo "Failed to locate the Eclipse Home directory."
     exit 0
   fi
-  osgiJar=`find ${eclipse_home} -name "org.eclipse.osgi_*.jar"`
+  osgiJar=$(find ${eclipse_home} -name "org.eclipse.osgi_*.jar" 2>/dev/null | head -1)
 }
 
 function setup_jar () {


### PR DESCRIPTION
In the case that the Eclipse installation has been updated
multiple OSGi jars will be found, causing the java -classpath
command line argument to be incorrect as it will have a space
in it.